### PR TITLE
refactor: reuse reset button styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
      <img src="attached_assets/hero image.png" class="splash-image" alt="TaskVenture Splash">
      <img src="attached_assets/gem.png"         class="gem"          alt="Gem">
      <img src="attached_assets/logo.png"        class="logo"         alt="Logo">
-        <button id="reset-wizard" title="Dev: Reset Wizard">🔄</button>
+        <button id="reset-wizard" class="reset-btn" title="Dev: Reset Wizard">🔄</button>
         <button id="play-button">PLAY</button>
     </div>
 

--- a/quest-styles.css
+++ b/quest-styles.css
@@ -45,26 +45,8 @@
 }
 
 .reset-quests-btn {
-    position: fixed;
     bottom: 15rem;
     right: 1.5rem;
-    background: var(--surface-glass);
-    backdrop-filter: blur(10px);
-    border: var(--glass-border);
-    border-radius: 50%;
-    width: 36px;
-    height: 36px;
-    color: var(--text-muted);
-    font-size: 1.2rem;
-    cursor: pointer;
-    transition: all 0.3s ease;
-}
-
-.reset-quests-btn:hover {
-    transform: translateY(-3px) scale(1.1);
-    box-shadow:
-        0 30px 60px rgba(0, 0, 0, 0.4),
-        var(--shadow-glow);
 }
 
 .quest-list h3 {

--- a/quests.js
+++ b/quests.js
@@ -2290,7 +2290,7 @@ class QuestEngine {
             <div class="quest-list">
                 <div class="quest-header-controls">
                     <h2>Available Quests</h2>
-                    <button onclick="questEngine.resetAllQuests()" class="reset-quests-btn">🔄</button>
+                    <button onclick="questEngine.resetAllQuests()" class="reset-btn reset-quests-btn">🔄</button>
                 </div>
                 <div class="available-quests">
                     ${this.availableQuests

--- a/styles.css
+++ b/styles.css
@@ -155,10 +155,8 @@ body {
   }
 }
 
-#reset-wizard {
+.reset-btn {
   position: fixed;
-  bottom: 1rem;
-  right: 1rem;
   background: var(--surface-glass);
   backdrop-filter: blur(10px);
   border: var(--glass-border);
@@ -171,11 +169,16 @@ body {
   transition: all 0.3s ease;
 }
 
-#reset-wizard:hover {
+.reset-btn:hover {
   transform: translateY(-3px) scale(1.1);
   box-shadow:
     0 30px 60px rgba(0, 0, 0, 0.4),
     var(--shadow-glow);
+}
+
+#reset-wizard {
+  bottom: 1rem;
+  right: 1rem;
 }
 
 #play-button {


### PR DESCRIPTION
## Summary
- consolidate reset button styles into a reusable `.reset-btn` class
- use the shared class for wizard and quest reset buttons
- remove duplicated hover and base styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8c9e8144832389636a78a5f7342e