### PR TITLE
Remove vendor-prefixed rotate animation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -130,27 +130,12 @@ body {
 }
 
 .gem:hover {
-  -webkit-animation: rotate 1s;
-  -moz-animation: rotate 1s;
   animation: rotate .9s;
   filter: drop-shadow(0 0 1rem rgb(128, 255, 255));
 }
 
-@-moz-keyframes rotate {
-  100% {
-    -moz-transform: rotateY(360deg);
-  }
-}
-
-@-webkit-keyframes rotate {
-  100% {
-    -webkit-transform: rotateY(360deg);
-  }
-}
-
 @keyframes rotate {
   100% {
-    -webkit-transform: rotateY(2160deg);
     transform: rotateY(2160deg);
   }
 }


### PR DESCRIPTION
## Summary
- drop `-moz` and `-webkit` prefixed rotate animations
- keep standard `@keyframes rotate` and `animation`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8c8a69e483238f22658fa75b7bda