### PR TITLE
Remove DOMContentLoaded wrappers from deferred scripts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,31 +1,24 @@
 // app.js
 
-// Wait for DOM to be ready before initializing
-document.addEventListener('DOMContentLoaded', function() {
-    // Ensure initial visibility is set immediately to prevent flash
-    if (document.documentElement) {
-        document.documentElement.style.setProperty("--initial-load", "true");
-    }
-});
+// Ensure initial visibility is set immediately to prevent flash
+if (document.documentElement) {
+    document.documentElement.style.setProperty("--initial-load", "true");
+}
 
-// Initialize DOM elements after DOM is ready
-let splashEl, wizardEl, gameEl;
+// Initialize DOM elements
+let splashEl = document.getElementById("splash-screen");
+let wizardEl = document.getElementById("wizard");
+let gameEl   = document.getElementById("game-interface");
 
-document.addEventListener('DOMContentLoaded', function() {
-    splashEl = document.getElementById("splash-screen");
-    wizardEl = document.getElementById("wizard");
-    gameEl = document.getElementById("game-interface");
+// Immediately hide game interface to prevent flash
+if (gameEl) gameEl.style.display = "none";
+if (wizardEl) wizardEl.style.display = "none";
 
-    // Immediately hide game interface to prevent flash
-    if (gameEl) gameEl.style.display = "none";
-    if (wizardEl) wizardEl.style.display = "none";
+// Initialize the app
+initializeApp();
 
-    // Initialize the app after DOM is ready
-    initializeApp();
-
-    // Setup wellness notification listeners
-    setupWellnessNotificationListeners();
-});
+// Setup wellness notification listeners
+setupWellnessNotificationListeners();
 
 // Setup wellness notification event listeners
 function setupWellnessNotificationListeners() {
@@ -2664,10 +2657,8 @@ function setupHeaderAvatarLayout() {
 }
 
 // Call it when the app shows the game UI
-document.addEventListener("DOMContentLoaded", () => {
-    // If you already call enterApp(), also call this after you show the game interface:
-    setupHeaderAvatarLayout();
-});
+// If you already call enterApp(), also call this after you show the game interface:
+setupHeaderAvatarLayout();
 
 // Also call after page switches (so it picks the active panel’s top)
 // If you have a showPage function, add:
@@ -2686,10 +2677,8 @@ window.updateUI = function () {
 };
 
 // Allow Enter key to add tasks and set up button handler
-document.addEventListener("DOMContentLoaded", function () {
-    // Initialize avatar customization when DOM is loaded
-    setTimeout(initializeAvatarCustomization, 100);
-});
+// Initialize avatar customization
+setTimeout(initializeAvatarCustomization, 100);
 
 // Set up task input handlers when the game interface becomes visible
 function setupTaskInputHandlers() {

--- a/dice.js
+++ b/dice.js
@@ -490,18 +490,16 @@ function ensureDiceInitialized() {
   return !!renderer;
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  setTimeout(() => { ensureDiceInitialized(); }, 600);
+setTimeout(() => { ensureDiceInitialized(); }, 600);
 
-  // if your app toggles views (quests/combat), try again when it becomes active
-  const target = document.getElementById('quests-page') || document.getElementById('dice-page');
-  if (target) {
-    const observer = new MutationObserver(() => {
-      if (target.classList.contains('active')) setTimeout(() => ensureDiceInitialized(), 400);
-    });
-    observer.observe(target, { attributes: true });
-  }
-});
+// if your app toggles views (quests/combat), try again when it becomes active
+const target = document.getElementById('quests-page') || document.getElementById('dice-page');
+if (target) {
+  const observer = new MutationObserver(() => {
+    if (target.classList.contains('active')) setTimeout(() => ensureDiceInitialized(), 400);
+  });
+  observer.observe(target, { attributes: true });
+}
 
 // Expose a couple helpers
 window.ensureDiceInitialized = ensureDiceInitialized;

--- a/quests.js
+++ b/quests.js
@@ -2409,19 +2409,16 @@ function showFloatingMessage(message, type = 'info') {
 }
 
 
-// Initialize quest engine when DOM loads
-document.addEventListener("DOMContentLoaded", () => {
-    // Check if questEngine already exists to avoid reinitialization if this script is loaded multiple times
-    if (!window.questEngine) {
-        window.questEngine = new QuestEngine();
-        // Render the quest list initially if the container is present
-        setTimeout(() => {
-            if (document.getElementById("quest-container")) {
-                window.questEngine.renderQuestList();
-            }
-        }, 500); // Small delay to ensure DOM is ready
-    }
-});
+// Initialize quest engine
+if (!window.questEngine) {
+    window.questEngine = new QuestEngine();
+    // Render the quest list initially if the container is present
+    setTimeout(() => {
+        if (document.getElementById("quest-container")) {
+            window.questEngine.renderQuestList();
+        }
+    }, 500); // Small delay to ensure DOM is ready
+}
 
 // Also initialize when showing the quests page
 window.initializeQuestsPage = function () {

--- a/settings.js
+++ b/settings.js
@@ -11,9 +11,7 @@ function playClickSound() {
     clickSound.play().catch(e => console.warn('Click sound blocked:', e));
 }
 
-document.addEventListener('DOMContentLoaded', function() {
-    initializeSettings();
-});
+initializeSettings();
 
 function initializeSettings() {
     // Load saved settings

--- a/sheet.js
+++ b/sheet.js
@@ -778,5 +778,5 @@
 
   // 3) Expose for app.js and auto‐render on load
   window.renderSheet = renderSheet;
-  document.addEventListener('DOMContentLoaded', renderSheet);
+  renderSheet();
 })();

--- a/wizard.js
+++ b/wizard.js
@@ -1,5 +1,5 @@
 // wizard.js
-document.addEventListener("DOMContentLoaded", () => {
+(() => {
   // 1) Cache DOM
   const splashEl   = document.getElementById("splash-screen");
   const wizardEl   = document.getElementById("wizard");
@@ -181,4 +181,4 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // 11) kick off at step 0
   showStep(0);
-});
+})();


### PR DESCRIPTION
## Summary
- Run app initialization immediately in `app.js` and call layout/customization helpers without DOMContentLoaded.
- Execute wizard logic and settings initialization on load by replacing DOMContentLoaded handlers with direct calls.
- Drop DOMContentLoaded listeners in sheet, dice, and quests modules so they initialize as soon as deferred scripts run.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8c6faa588323908817b0432361bb